### PR TITLE
remove lookbehind expression

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import type { Plugin } from 'unified';
 import type { Root, Nodes, Text } from 'mdast';
 
 const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
-const RE_SHORT = /(?<=\s|^)[@$|*'",;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}(?=\s|$|[.?!,])/g;
+const RE_SHORT = /(^|\s)[@$|*'",;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}/g;
 const RE_PUNCT = /(?:_|-(?!1))/g;
 
 /**
@@ -67,14 +67,17 @@ const plugin: Plugin<[(RemarkEmojiOptions | null | undefined)?], Root> = options
     function replaceEmoticon(match: string): string | false | Text {
         // find emoji by shortcode - full match or with-out last char as it could be from text e.g. :-),
         const iconFull = emoticon.find(e => e.emoticons.includes(match)); // full match
-        const iconPart = emoticon.find(e => e.emoticons.includes(match.slice(0, -1))); // second search pattern
-        const icon = iconFull || iconPart;
+        const iconPartStart = emoticon.find(e => e.emoticons.includes(match.slice(0, -1))); // second search pattern
+        const iconPartEnd = emoticon.find(e => e.emoticons.includes(match.slice(1)));
+        const iconPart = emoticon.find(e => e.emoticons.includes(match.slice(1, -1)));
+        const icon = iconFull || iconPartStart || iconPartEnd || iconPart;
         if (!icon) {
             return false;
         }
-        const trimmedChar = !iconFull && iconPart ? match.slice(-1) : '';
+        const trimmedChar = !(iconFull || iconPartEnd) && (iconPart || iconPartStart) ? match.slice(-1) : '';
+        const startTrimmedChar = !(iconFull || iconPartStart) && (iconPart || iconPartEnd) ? match.slice(0, 1) : '';
         const addPad = pad ? ' ' : '';
-        const replaced = icon.emoji + addPad + trimmedChar;
+        const replaced = startTrimmedChar + icon.emoji + addPad + trimmedChar;
         if (accessible) {
             return aria(replaced, icon.name + ' emoticon');
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remark-emoji",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-emoji",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-emoji",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "type": "module",
   "engines": {
     "node": ">=18"

--- a/test.ts
+++ b/test.ts
@@ -200,6 +200,7 @@ describe('remark-emoji', function () {
 
         it('handles emoji shortcodes (emoticon)', async function () {
             const tests: Record<string, string> = {
+                'with space :o, and comma': 'with space 😮, and comma\n',
                 'WARN:Danger': 'WARN:Danger\n',
                 'https://github.com': 'https://github.com\n',
                 ':p': '😛\n',


### PR DESCRIPTION
removes the lookbehind causing our compatibility issue in favor of better handling of whitespace in the replace function

